### PR TITLE
Fix pagination not updating data

### DIFF
--- a/src/app/species/page.tsx
+++ b/src/app/species/page.tsx
@@ -2,8 +2,7 @@
 import Link from "next/link";
 import { Dna } from "lucide-react";
 import PaginationFloating from "@/components/PaginationFloating";
-import { getAllSpecies } from "@/lib/api";
-import type { Species } from "@/lib/types";
+import { getSpeciesPage } from "@/lib/api";
 import BackToTopButton from "@/components/BackToTopButton";
 
 export const metadata = {
@@ -16,13 +15,7 @@ export default async function SpeciesPage({
     searchParams?: { page?: string };
 }) {
     const page = Number(searchParams?.page ?? 1);
-    const data = await getAllSpecies(page);
-
-    // Handle both array and paginated responses
-    const list: Species[] = Array.isArray(data) ? data : data.results ?? [];
-    const hasMore = Array.isArray(data)
-        ? list.length >= 10
-        : Boolean((data as { next?: string | null }).next);
+    const { list, hasMore } = await getSpeciesPage(page);
 
     return (
         <section className="max-w-6xl mx-auto px-4 py-14 space-y-8 text-[var(--foreground)]">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -93,20 +93,20 @@ export async function getPerson(id: string): Promise<Person> {
 }
 
 export async function getPeoplePage(
-  page: number
+page: number
 ): Promise<{ list: Person[]; hasMore: boolean }> {
-  const response = await getResource<
-    Person[] | { results?: Person[]; next?: string | null }
-  >(`/people?page=${page}`);
+const response = await getResource<
+Person[] | { results?: Person[]; next?: string | null }
+>(`/people?page=${page}`);
+const fullList = Array.isArray(response)
+? response
+: response.results ?? [];
+const list = fullList.slice((page - 1) * 10, page * 10);
+const hasMore = Array.isArray(response)
+? page * 10 < fullList.length
+: Boolean((response as { next?: string | null }).next);
 
-  const list = Array.isArray(response)
-    ? response
-    : response.results ?? [];
-  const hasMore = Array.isArray(response)
-    ? list.length >= 10
-    : Boolean((response as { next?: string | null }).next);
-
-  return { list, hasMore };
+return { list, hasMore };
 }
 
 /* ------------------ Film Wrappers ------------------ */
@@ -117,12 +117,21 @@ export async function getFilm(id: string): Promise<Film> {
 
 /* ------------------ Species Wrappers ------------------ */
 
-export async function getAllSpecies(
-  page: number
-): Promise<Species[] | { results?: Species[]; next?: string | null }> {
-  return getResource<Species[] | { results?: Species[]; next?: string | null }>(
-    `/species?page=${page}`
-  );
+export async function getSpeciesPage(
+page: number
+): Promise<{ list: Species[]; hasMore: boolean }> {
+const response = await getResource<
+Species[] | { results?: Species[]; next?: string | null }
+>(`/species?page=${page}`);
+const fullList = Array.isArray(response)
+? response
+: response.results ?? [];
+const list = fullList.slice((page - 1) * 10, page * 10);
+const hasMore = Array.isArray(response)
+? page * 10 < fullList.length
+: Boolean((response as { next?: string | null }).next);
+
+return { list, hasMore };
 }
 
 export async function getSpeciesByName(


### PR DESCRIPTION
## Summary
- implement manual page slicing in `getPeoplePage`
- add `getSpeciesPage` and update species page

## Testing
- `npm run lint`
- `npm run build` *(fails: fetch failed during pre-render)*

------
https://chatgpt.com/codex/tasks/task_e_685199cbe7e4832a96eaa7878bec1d4d